### PR TITLE
WIP/Feedback: New bandstructure visualiser?

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "bands-visualiser": "file:bands-visualiser-0.0.1.tgz",
         "better-react-mathjax": "^2.0.3",
         "bootstrap": "^5.3.2",
-        "chart.js": "^4.4.1",
         "chartjs-plugin-annotation": "^3.0.1",
         "chartjs-plugin-zoom": "^2.0.1",
         "mathjs": "^13.2.0",
@@ -3933,7 +3932,8 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
@@ -7326,10 +7326,10 @@
     "node_modules/bands-visualiser": {
       "version": "0.0.1",
       "resolved": "file:bands-visualiser-0.0.1.tgz",
-      "integrity": "sha512-tIK2eyuI10EuPUFbrzQpmJpsuRKpFztyTDFTf6HEbaHOXYD/Eni4HAJFh9WFADJB5ZbOTbsyo5yJ+shKb9aoiw==",
+      "integrity": "sha512-JcY8aPw8mgFxqPShqeowITfVqap6ReMp3TyXwnlImb09N0c1WkS2DQVGBTcWyyxJnRlDPkBlxNeLjaD1BC3duA==",
       "dependencies": {
         "deepmerge": "^4.3.1",
-        "plotly.js-dist": "^3.0.1"
+        "plotly.js-basic-dist": "^3.0.1"
       }
     },
     "node_modules/base64-arraybuffer": {
@@ -7780,10 +7780,11 @@
       }
     },
     "node_modules/chart.js": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.8.tgz",
-      "integrity": "sha512-IkGZlVpXP+83QpMm4uxEiGqSI7jFizwVtF3+n5Pc3k7sMO+tkd0qxh2OzLhenM0K80xtmAONWGBn082EiBQSDA==",
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
+      "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -17531,10 +17532,10 @@
         "world-calendars": "^1.0.3"
       }
     },
-    "node_modules/plotly.js-dist": {
+    "node_modules/plotly.js-basic-dist": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-3.0.1.tgz",
-      "integrity": "sha512-/LvKEGxWime7KPzO6nlnfNyTt/pHn4Ctlgj98RUJyjUIu3IHowOqSu+tRq3B/xQ6GZWj5uDz2hS+eEBsgg/xHw==",
+      "resolved": "https://registry.npmjs.org/plotly.js-basic-dist/-/plotly.js-basic-dist-3.0.1.tgz",
+      "integrity": "sha512-TFhJjbCdOSp8IhxThlcaE9doaiBQ8gdFkBoyJ1UrsnLjJzsSGkNfVd2jl51WtOMiAxMSW0F1dtELEju4/cicnQ==",
       "license": "MIT"
     },
     "node_modules/point-in-polygon": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "discover-mc2d-react",
       "version": "0.0.0",
       "dependencies": {
+        "bands-visualiser": "file:bands-visualiser-0.0.1.tgz",
         "better-react-mathjax": "^2.0.3",
         "bootstrap": "^5.3.2",
         "chart.js": "^4.4.1",
@@ -7321,6 +7322,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/bands-visualiser": {
+      "version": "0.0.1",
+      "resolved": "file:bands-visualiser-0.0.1.tgz",
+      "integrity": "sha512-tIK2eyuI10EuPUFbrzQpmJpsuRKpFztyTDFTf6HEbaHOXYD/Eni4HAJFh9WFADJB5ZbOTbsyo5yJ+shKb9aoiw==",
+      "dependencies": {
+        "deepmerge": "^4.3.1",
+        "plotly.js-dist": "^3.0.1"
+      }
     },
     "node_modules/base64-arraybuffer": {
       "version": "1.0.2",
@@ -17520,6 +17530,12 @@
         "webgl-context": "^2.2.0",
         "world-calendars": "^1.0.3"
       }
+    },
+    "node_modules/plotly.js-dist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-3.0.1.tgz",
+      "integrity": "sha512-/LvKEGxWime7KPzO6nlnfNyTt/pHn4Ctlgj98RUJyjUIu3IHowOqSu+tRq3B/xQ6GZWj5uDz2hS+eEBsgg/xHw==",
+      "license": "MIT"
     },
     "node_modules/point-in-polygon": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "bands-visualiser": "file:bands-visualiser-0.0.1.tgz",
     "better-react-mathjax": "^2.0.3",
     "bootstrap": "^5.3.2",
-    "chart.js": "^4.4.1",
     "chartjs-plugin-annotation": "^3.0.1",
     "chartjs-plugin-zoom": "^2.0.1",
     "mathjs": "^13.2.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "bands-visualiser": "file:bands-visualiser-0.0.1.tgz",
     "better-react-mathjax": "^2.0.3",
     "bootstrap": "^5.3.2",
     "chart.js": "^4.4.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,13 +5,6 @@ import { Routes, Route, HashRouter } from "react-router-dom";
 import MainPage from "./MainPage";
 import DetailPage from "./DetailPage";
 
-// Chart.js plugins need to be registered outside the library
-import Chart from "chart.js/auto";
-import zoomPlugin from "chartjs-plugin-zoom";
-import annotationPlugin from "chartjs-plugin-annotation";
-Chart.register(zoomPlugin);
-Chart.register(annotationPlugin);
-
 function App() {
   return (
     <HashRouter>

--- a/src/DetailPage/VibrationalSection/index.jsx
+++ b/src/DetailPage/VibrationalSection/index.jsx
@@ -1,30 +1,46 @@
-import React, { useState, useEffect } from "react";
-
-import { McloudSpinner } from "mc-react-library";
-
-import { MCInfoBox } from "../components/MCInfoBox";
-
+import React, { useState, useEffect, useRef } from "react";
+import { McloudSpinner, ExploreButton } from "mc-react-library";
 import { Container, Row, Col } from "react-bootstrap";
 
-import BandsVisualizer from "mc-react-bands";
-
-import { ExploreButton } from "mc-react-library";
-
 import { loadAiidaBands, loadPhononVis } from "../../common/restApiUtils";
+import { EXPLORE_URL } from "../../common/restApiUtils";
 
-import { AIIDA_REST_API_URL, EXPLORE_URL } from "../../common/restApiUtils";
-
+import { BandsVisualiser } from "bands-visualiser"; // <- Your new npm package
 import PhononVisualizer from "mc-react-phonon-visualizer";
 
-const VibrationalSection = (props) => {
+// Component that wraps the BandsVisualiser into a React component
+const BandComponent = ({ bandsData, style }) => {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (!containerRef.current || !bandsData) return;
+
+    const bandsDataArray = [
+      {
+        bandsData: bandsData,
+        traceFormat: {
+          showlegend: false,
+          line: { width: 2.0, color: "#636EFA" },
+        },
+      },
+    ];
+
+    BandsVisualiser(containerRef.current, {
+      bandsDataArray,
+      settings: { yaxis: { title: { text: "Phonon bands [Thz]" } } },
+    });
+  }, [bandsData]);
+
+  return <div ref={containerRef} style={style} />;
+};
+
+const VibrationalSection = ({ loadedData, params }) => {
   const [bandsData, setBandsData] = useState(null);
   const [loadingBands, setLoadingBands] = useState(true);
   const [phononVisData, setPhononVisData] = useState(null);
 
-  let vibrationalData = props.loadedData.details.vibrational;
-  console.log("vibrationalData", vibrationalData);
-
-  let bandsUuid = vibrationalData.phonon_bands_uuid;
+  const vibrationalData = loadedData.details.vibrational;
+  const bandsUuid = vibrationalData.phonon_bands_uuid;
 
   useEffect(() => {
     setBandsData(null);
@@ -37,59 +53,18 @@ const VibrationalSection = (props) => {
       setLoadingBands(false);
     }
 
-    loadPhononVis(props.params.id).then((data) => {
+    loadPhononVis(params.id).then((data) => {
       setPhononVisData(data);
       console.log("Phonon visualizer data", data);
     });
-  }, []);
+  }, [bandsUuid, params.id]);
 
-  let bandsAvailable = bandsData != null;
-  let bandsJsx = "";
-  if (bandsAvailable) {
-    bandsJsx = (
-      <Row>
-        <Col className="flex-column">
-          <div className="subsection-title">
-            Phonon band structure{" "}
-            <ExploreButton explore_url={EXPLORE_URL} uuid={bandsUuid} />
-          </div>
-          <BandsVisualizer
-            bandsDataList={[bandsData]}
-            // energyRange={[-5.0, 5.0]}
-            bandsColorInfo={["#3560A0"]}
-            formatSettings={{
-              bandsYlabel: "Phonon bands (THz)",
-            }}
-          />
-        </Col>
-        <Col className="flex-column"></Col>
-      </Row>
-    );
-  }
-
-  let phononVisAvailable = phononVisData != null;
-  let phononVisJsx = "";
-  if (phononVisAvailable) {
-    // NOTE: The PhononVisualizer plotly clicking doesn't seem to work
-    // inside bootstrap <Container>! Keep it outside.
-    phononVisJsx = (
-      <div>
-        <div style={{ margin: "30px 0px 5px 12px" }}>
-          <div className="subsection-title">
-            Interactive phonon visualizer{" "}
-            <ExploreButton explore_url={EXPLORE_URL} uuid={bandsUuid} />
-          </div>
-        </div>
-        <PhononVisualizer
-          props={{ title: "Phonon visualizer", ...phononVisData }}
-        />
-      </div>
-    );
-  }
+  const bandsAvailable = bandsData != null;
 
   return (
     <div>
       <div className="section-heading">Vibrational properties</div>
+
       <Container fluid className="section-container">
         {loadingBands ? (
           <div style={{ width: "150px", padding: "40px", margin: "0 auto" }}>
@@ -98,10 +73,35 @@ const VibrationalSection = (props) => {
         ) : !bandsAvailable ? (
           <span>Vibrational properties not available for this structure.</span>
         ) : (
-          <>{bandsJsx}</>
+          <Row>
+            <Col className="flex-column">
+              <div className="subsection-title">
+                Phonon band structure{" "}
+                <ExploreButton explore_url={EXPLORE_URL} uuid={bandsUuid} />
+              </div>
+              <BandComponent
+                bandsData={bandsData}
+                style={{ height: "500px" }}
+              />
+            </Col>
+            <Col className="flex-column"></Col>
+          </Row>
         )}
       </Container>
-      {phononVisJsx}
+
+      {phononVisData && (
+        <div>
+          <div style={{ margin: "30px 0px 5px 12px" }}>
+            <div className="subsection-title">
+              Interactive phonon visualizer{" "}
+              <ExploreButton explore_url={EXPLORE_URL} uuid={bandsUuid} />
+            </div>
+          </div>
+          <PhononVisualizer
+            props={{ title: "Phonon visualizer", ...phononVisData }}
+          />
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
WIP PR; 
Wordy desc. below - not expecting you to read it, we can chat potentially.

Just rewrote the phonon and bands index files to incorporate the bands visualiser ive been working on. Mostly a new component that wraps the plotly plot into a div (with some formatting) 

In principle it should be fairly easy to add this re-arrange bands button/download jsons but decided to keep the component clean for now. I dont know if CBM and VBM are passed through aiida/easy to calculate  but the component should be able to accept singular traces (lines/markers) as input so if its easy to calculate we could maybe throw that in too? (this raises a question on legend etc, the legend is always going to be quite big or quite unreadable). 

Could be an idea to show VBM and CBM where applicable as text+marker inside the textbox to the right.

There is a moderate disconnect now with the plotly plotter in the interactive section (albeit less than before), I think the one there looks great and we can maybe restyle the ones in the main body to match it, or  make a small change on that components end?

